### PR TITLE
Update to Alpine 3.7, GraphViz 2.40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:3.4
+FROM alpine:3.7
 MAINTAINER Fabio Rehm "fgrehm@gmail.com"
+WORKDIR /graphviz
 RUN apk add --update --no-cache \
            graphviz \
            ttf-freefont

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # docker-graphviz
+
 Graphviz in an Alpine Linux container
+
+# Usage
+
+    docker run --rm -v $(PWD):/graphviz fgrehm/graphviz dot -Tpng -o out.png input.dot
+
+# Makefile example
+
+Create a `Makefile` similar to the one below.  NOTE: make requires tab characters to be used for indentation so you will need to change spaces to tabs if you copy paste this text.
+
+	.PHONY = render
+	FORMAT = png
+	TARGETS = $(patsubst %.dot,%.$(FORMAT),$(wildcard *.dot))
+	VIEWER = tty -s && test -x /Applications && open -a preview
+
+	render: $(TARGETS)
+
+	%.$(FORMAT): %.dot
+		docker run --rm -v $(PWD):/graphviz fgrehm/graphviz dot -T$(FORMAT) -o $@ $<
+		$(VIEWER) $@ || true
+
+Assuming you have a `services.dot`, you can create and preview (on macOS) `services.png` with:
+
+	make
+
+If you prefer a different format such as `pdf`:
+
+	make FORMAT=pdf


### PR DESCRIPTION
This PR:

- updates to Alpine 3.7 which ships GraphViz 2.40 (fixes #1)
- sets the default workdir to `/graphviz` (scratch area)
- adds usage and Makefile examples to the README